### PR TITLE
Add PDF subscription parser script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # PDFParser
+
+This repository contains a small script to extract subscription-related lines from a credit card statement PDF.
+
+## Setup
+
+Install the dependencies using pip:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+Run the parser with the path to your PDF statement:
+
+```bash
+python parse_subscriptions.py /path/to/statement.pdf
+```
+
+The script will display lines that look like subscriptions in a table. You can choose a number to remove an entry as a way to "cancel" it. This is a demonstration and does not actually cancel services.

--- a/parse_subscriptions.py
+++ b/parse_subscriptions.py
@@ -1,0 +1,62 @@
+import sys
+import re
+import pdfplumber
+from tabulate import tabulate
+
+SUBSCRIPTION_KEYWORDS = [
+    "subscription",
+    "recurring",
+    "monthly",
+    "autopay",
+]
+
+def extract_text(pdf_path: str) -> str:
+    text = ""
+    with pdfplumber.open(pdf_path) as pdf:
+        for page in pdf.pages:
+            page_text = page.extract_text()
+            if page_text:
+                text += page_text + "\n"
+    return text
+
+def parse_subscriptions(text: str):
+    lines = text.splitlines()
+    matches = []
+    for line in lines:
+        line_lc = line.lower()
+        if any(keyword in line_lc for keyword in SUBSCRIPTION_KEYWORDS):
+            matches.append(line.strip())
+    return matches
+
+def main(pdf_path: str):
+    text = extract_text(pdf_path)
+    subscriptions = parse_subscriptions(text)
+    if not subscriptions:
+        print("No subscriptions found.")
+        return
+    table = [[idx + 1, sub] for idx, sub in enumerate(subscriptions)]
+    print(tabulate(table, headers=["#", "Line"], tablefmt="github"))
+    while True:
+        choice = input("Enter the number of the subscription to cancel (or 'q' to quit): ")
+        if choice.lower() == 'q':
+            break
+        if not choice.isdigit():
+            print("Invalid choice.")
+            continue
+        idx = int(choice) - 1
+        if idx < 0 or idx >= len(subscriptions):
+            print("Invalid choice.")
+            continue
+        print(f"Canceling subscription: {subscriptions[idx]}")
+        subscriptions.pop(idx)
+        if not subscriptions:
+            print("No more subscriptions.")
+            break
+        table = [[i + 1, sub] for i, sub in enumerate(subscriptions)]
+        print(tabulate(table, headers=["#", "Line"], tablefmt="github"))
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} path/to/statement.pdf")
+        sys.exit(1)
+    main(sys.argv[1])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pdfplumber
+tabulate


### PR DESCRIPTION
## Summary
- add a simple PDF subscription parser using pdfplumber
- add dependency list
- document usage in README

## Testing
- `python3 -m py_compile parse_subscriptions.py`